### PR TITLE
Add func for GetNameForLevel

### DIFF
--- a/level.go
+++ b/level.go
@@ -196,4 +196,14 @@ var (
 		}
 		return ""
 	}
+	
+	// GetNameForLevel is the function which
+        // has the "final" responsibility to generagte the name of the level
+        // that is prepended to the leveled log message
+        GetNameForLevel = func(level Level) string {
+                if meta, ok := Levels[level]; ok {
+                        return meta.Name
+                }
+                return ""
+        }
 )

--- a/level.go
+++ b/level.go
@@ -198,12 +198,12 @@ var (
 	}
 	
 	// GetNameForLevel is the function which
-        // has the "final" responsibility to generagte the name of the level
-        // that is prepended to the leveled log message
-        GetNameForLevel = func(level Level) string {
-                if meta, ok := Levels[level]; ok {
-                        return meta.Name
-                }
-                return ""
-        }
+	// has the "final" responsibility to generagte the name of the level
+	// that is prepended to the leveled log message
+	GetNameForLevel = func(level Level) string {
+		if meta, ok := Levels[level]; ok {
+			return meta.Name
+		}
+		return ""
+	}
 )


### PR DESCRIPTION
When set customized-output, it may the Name of the level useful rather than
the Text(colorful or not) of the level.

```
golog.Handle(func(l *golog.Log) bool {
                prefix := golog.GetNameForLevel(l.Level)
                pc, fn, line, _ := runtime.Caller(7)
                message := fmt.Sprintf("%s line %d (%s) (%s) %s: %s",
                        prefix, line, runtime.FuncForPC(pc).Name(), fn, l.FormatTime(), l.Message)

                if l.NewLine {
                        message += "\n"
                }

                fmt.Print(message)
                return true
})
```

will out like:
``
warn line 26 (main.main) (/home/pato/go/src/github.com/kataras/golog/_examples/customize-output/main.go) 2018/09/10 09:57: Hey, warning here
``

Thanks.